### PR TITLE
xnat 1.7 compatibility

### DIFF
--- a/sn-editor/package.json
+++ b/sn-editor/package.json
@@ -22,5 +22,11 @@
     "start": "NODE_PATH=src react-scripts start",
     "build": "NODE_PATH=src react-scripts build",
     "deploy": "rsync --recursive --compress --delete --stats --human-readable --exclude '*.edf' build/* xnat:~/copla-editor"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/sn-editor/src/xnat/XNAT.js
+++ b/sn-editor/src/xnat/XNAT.js
@@ -20,6 +20,7 @@ export default class XNAT {
 
    urls = {
       session: '{host}/JSESSION', // https://wiki.xnat.org/pages/viewpage.action?pageId=6226264
+      auth: '{host}/auth',
    }
 
    getProjects = utils.getChildren(Project)
@@ -58,8 +59,10 @@ export default class XNAT {
    }
 
    checkLogin() {
-      const url = utils.tpl(this.urls.session, this.data);
-      return http.get(url).then(() => true, () => false);
+    const url = utils.tpl(this.urls.auth, this.data);
+    return http.get(url, { redirect: 'manual' })
+      .then(response => response.ok)
+      .catch(() => false);
    }
 
    checkIfHostIsReachable() {
@@ -70,6 +73,11 @@ export default class XNAT {
          .then(() => true, () => false);
    }
 
+  getSession() {
+    const url = utils.tpl(this.urls.session, this.data);
+    return http.get(url).then(response => response.text());
+  }
+
    renewSession() {
       const url = utils.tpl('{host}/version', this.data);
       return http.get(url).then(
@@ -79,10 +87,10 @@ export default class XNAT {
    }
 
    whoami() {
-      const url = utils.tpl('{host}/auth', this.data);
-      const pattern = /User '(\w+)' is logged in/; // hard coded in UserAuth.java
-      return http.getText(url)
-         .then(text => _.last(text.match(pattern)));
+    const url = utils.tpl(this.urls.auth, this.data);
+    const pattern = /User '(\w+)' is logged in/; // hard coded in UserAuth.java
+    return http.getText(url)
+      .then(text => _.last(text.match(pattern)))
+      .catch(() => null);
    }
-
 }

--- a/sn-editor/src/xnat/XNAT.js
+++ b/sn-editor/src/xnat/XNAT.js
@@ -45,7 +45,7 @@ export default class XNAT {
       const url = utils.tpl(this.urls.session, this.data);
       const credentials = window.btoa(`${username}:${password}`);
 
-      return http.get(url, {
+      return http.post(url, {
          headers: {
             Authorization: `Basic ${credentials}`,
          },


### PR DESCRIPTION
I've made some updates to get this working with xnat 1.7.

I  used the version of `XNAT.js` in [cpet_frontend](https://git.tools.f4.htw-berlin.de/copla/cpet-frontend/) as a jumping off point, then did some minor clean up. See the commit history in this PR for more detail.

I have tested this against xnat 1.7 locally using [this set up](https://github.com/somnonetz/xnat-docker-compose)

I have not tested to see if this breaks 1.6 compatibility, is this required?