### PR TITLE
add ability to select project and subject

### DIFF
--- a/sn-editor/src/components/FileBrowser.js
+++ b/sn-editor/src/components/FileBrowser.js
@@ -31,9 +31,9 @@ export default class FileBrowser extends Component {
             onUpload={onUpload}
           />
         )}
-        {bundles.filter(b => b.isLocal).length >= 2 &&
+        {/*bundles.filter(b => b.isLocal).length >= 2 &&
           <button className="btn btn-primary full-width m-t-1" onClick={console.log}>Upload all</button>
-        }
+        */}
       </div>
     );
   }

--- a/sn-editor/src/components/Upload.js
+++ b/sn-editor/src/components/Upload.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Countdown from 'components/Countdown';
 import Experiment from 'xnat/Experiment';
+import Project from 'xnat/Project'
+import Subject from 'xnat/Subject'
 import { sleep } from 'utils/utils';
-import { host, defaultProject, defaultSubject, pipelineName, pipelineParams } from 'config';
+import { host, pipelineName, pipelineParams } from 'config';
 
 const STATES = {
   DESTINED: 1,
@@ -21,6 +23,8 @@ export default class Upload extends Component {
   static propTypes = {
     bundle: PropTypes.object.isRequired,
     onFinish: PropTypes.func,
+    project: PropTypes.instanceOf(Project),
+    subject: PropTypes.instanceOf(Subject),
   }
 
   static defaultProps = {
@@ -48,13 +52,16 @@ export default class Upload extends Component {
 
   getExperiment = () => {
     // const name = this.props.bundle.edf.header.recordIdentification.replace(/\s/g, '_');
+    const { project, subject } = this.props;
+
     const options = {
       host,
-      subject: defaultSubject,
-      project: defaultProject,
-      experiment: Math.random().toString(32).slice(2), // name,
+      subject: subject.data.subject,
+      project: project.data.project,
+      experiment: Math.random().toString(32).slice(2), //name
       type: 'snet01:sleepResearchSessionData',
     };
+
     return new Experiment(options);
   }
 
@@ -114,6 +121,7 @@ export default class Upload extends Component {
 
   render() {
     const { uploadStatus, error } = this.state;
+    const { project, subject } = this.props;
     const filename = this.props.bundle.edf.file.name;
     const progress = `${this.state.progress.toFixed(2)}%`;
     const Alert = ({ type = 'info', children }) => <div className={`alert alert-${type}`}>{children}</div>;
@@ -148,7 +156,7 @@ export default class Upload extends Component {
       default: // STATES.DESTINED and no state (which should not happen)
         return (
           <div className="list-group m-b-1">
-            <p>Will upload <code>{filename}</code> into <code>{defaultProject}/{defaultSubject}</code>.</p>
+            <p>Will upload <code>{filename}</code> into <code>{project.data.project}/{subject.data.subject_label}</code>.</p>
             <button onClick={this.startUpload}>Start Upload</button>
           </div>
         );

--- a/sn-editor/src/index.css
+++ b/sn-editor/src/index.css
@@ -26,3 +26,12 @@
   justify-content: space-between;
   align-items: baseline;
 }
+
+.select-box {
+  display: block;
+  margin: 0.5rem;
+}
+
+.select-box select {
+  width: 100%;
+}

--- a/sn-editor/src/xnat/Subject.js
+++ b/sn-editor/src/xnat/Subject.js
@@ -23,6 +23,7 @@ export default class Subject extends Base {
    initialize(data) {
       this.data = utils.rename(data, {
          ID: 'subject',
+         label: 'subject_label',
       });
       this.data.query = this.getQuery();
    }


### PR DESCRIPTION
add project and subject select boxes to sn-editor, so that users can
select which project and subject they want to upload to.

![Screenshot from 2020-03-23 20-54-26](https://user-images.githubusercontent.com/9866884/77357489-8edad380-6d48-11ea-88f9-063ad71ed761.png)

this PR also disables the "Upload all" button, because it didn't do anything but log to the console (looks like unfinished work)